### PR TITLE
ajout dependent destroy sur models + ajout columns DB + ajout items e…

### DIFF
--- a/app/models/deck.rb
+++ b/app/models/deck.rb
@@ -2,5 +2,5 @@ class Deck < ApplicationRecord
   belongs_to :user
   validates :name, presence: true
 
-  has_many :deck_items
+  has_many :deck_items, dependent: :destroy
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,5 +5,5 @@ class Item < ApplicationRecord
   validates :photo_url, presence: true
   validates :price_range, presence: true
 
-  has_many :deck_items
+  has_many :deck_items, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  has_many :decks
-  has_many :votes
+  has_many :decks, dependent: :destroy
+  has_many :votes, dependent: :destroy
 end

--- a/db/migrate/20230307132654_change_type_column_on_item.rb
+++ b/db/migrate/20230307132654_change_type_column_on_item.rb
@@ -1,0 +1,5 @@
+class ChangeTypeColumnOnItem < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :items, :type, :item_type
+  end
+end

--- a/db/migrate/20230307134721_add_type_to_decks.rb
+++ b/db/migrate/20230307134721_add_type_to_decks.rb
@@ -1,0 +1,5 @@
+class AddTypeToDecks < ActiveRecord::Migration[7.0]
+  def change
+    add_column :decks, :deck_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_06_165558) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_07_134721) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,9 +27,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_06_165558) do
     t.string "name"
     t.bigint "user_id", null: false
     t.string "status"
-    #status is either "Pending" or "Closed"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "deck_type"
     t.index ["user_id"], name: "index_decks_on_user_id"
   end
 
@@ -38,7 +38,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_06_165558) do
     t.string "address"
     t.float "rating"
     t.integer "price_range"
-    t.string "type"
+    t.string "item_type"
     t.string "photo_url"
     t.string "item_url"
     t.datetime "created_at", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,25 +10,123 @@ require "open-uri"
 
 puts "Cleaning database..."
 User.destroy_all
-Deck.destroy_all
-Deck_item.destroy_all
 Item.destroy_all
-Vote.destroy_all
+Deck.destroy_all
+
 
 puts "Creating users..."
-guillaume = User.create!(username: "Guillaume", email: "guillaume@hello.fr", password: "123456", phone: "07 77 72 64 44")
-audrey = User.create!(username: "Audrey", email: "audrey@hello.fr", password: "123456", phone: "06 32 45 67 89")
-hugo = User.create!(username: "Hugo", email: "hugo@hello.fr", password: "123456", phone: "06 12 34 56 78")
-robin = User.create!(username: "Robin", email: "robin@hello.fr", password: "123456", phone: "07 98 76 54 32")
+guillaume = User.create!(username: "Guillaume", email: "guillaume@hello.fr", password: "123456", phone_number: "07 77 72 64 44")
+audrey = User.create!(username: "Audrey", email: "audrey@hello.fr", password: "123456", phone_number: "06 32 45 67 89")
+hugo = User.create!(username: "Hugo", email: "hugo@hello.fr", password: "123456", phone_number: "06 12 34 56 78")
+robin = User.create!(username: "Robin", email: "robin@hello.fr", password: "123456", phone_number: "07 98 76 54 32")
 puts "Users created"
 
 puts "Creating 1 Pending Deck and 2 Closed Decks for Hugo..."
-restaurantdeck1 = Deck.create!(name: "hugo1-rest-230301", status: "Pending", user: hugo)
-restaurantdeck2 = Deck.create!(name: "hugo2-rest-230302", status: "Closed", user: hugo)
-restaurantdeck3 = Deck.create!(name: "hugo3-rest-230303", status: "Closed", user: hugo)
+restaurantdeck1 = Deck.create!(name: "hugo1-rest-230301", status: "Pending", user: hugo, deck_type: "Restaurant")
+restaurantdeck2 = Deck.create!(name: "hugo2-rest-230302", status: "Closed", user: hugo, deck_type: "Restaurant")
+restaurantdeck3 = Deck.create!(name: "hugo3-rest-230303", status: "Closed", user: hugo, deck_type: "Restaurant")
 puts "Decks created"
 
-# puts "Creating 5 Restaurants for Pending deck..."
-# puts "Restaurants created"
-# puts "Creating 5 Restaurants for Future deck..."
-# puts "Restaurants created"
+puts "Creating 5 Restaurants for Pending deck..."
+item1 = Item.create!(
+  name: "Sürpriz - Berliner Kebab",
+  item_url: "https://www.surpriz.paris/",
+  address: "110 Rue Oberkampf, 75011 Paris",
+  rating: 4.7,
+  price_range: 1,
+  item_type: "Restaurant",
+  photo_url: "https://storage.googleapis.com/mon-resto-halal/restaurants/ce93030e-dbe8-4357-9cce-c630fc628c75/thumb@1024_e1df9f14-b6ba-453c-85bc-ac6dab538cf8.jpg"
+)
+item2 = Item.create!(
+  name: "Sukhumvit Thaï Street Food Paris 11",
+  item_url: "https://www.instagram.com/sukhumvit.paris11/",
+  address: "88 Rue Oberkampf, 75011 Paris",
+  rating: 4.7,
+  price_range: 0,
+  item_type: "Restaurant",
+  photo_url: "https://lh3.googleusercontent.com/p/AF1QipPX6bNfUxmIoN4atu0Y8HavtfYQJIDX-T_h3wLh=w1080-h608-p-no-v0"
+)
+item3 = Item.create!(
+  name: "Boulangerie Chambelland",
+  item_url: "https://chambelland.com/",
+  address: "14 Rue Ternaux, 75011 Paris",
+  rating: 4.4,
+  price_range: 2,
+  item_type: "Restaurant",
+  photo_url: "https://www.ixelles.city/_custom_storage/collections/137/chambelland_20190517_73670.jpg"
+)
+item4 = Item.create!(
+  name: "Açaï & You - St Ambroise (Brunch & Bowls Take away)",
+  item_url: "http://www.acaiandyou.com/",
+  address: "28 Rue Saint-Ambroise, 75011 Paris",
+  rating: 4.8,
+  price_range: 0,
+  item_type: "Restaurant",
+  photo_url: "https://meilleur-brunch.com/wp-content/uploads/2021/11/acaiandyou2_5_1125.jpeg"
+)
+item5 = Item.create!(
+  name: "Scaria",
+  item_url: "http://scaria.fr/",
+  address: "88 Ave Parmentier, 75011 Paris",
+  rating: 4.6,
+  price_range: 2,
+  item_type: "Restaurant",
+  photo_url: "https://v2cdn1.centralappstatic.com/cache?url=gwBZASxXb5aRoDFLzKC_tPBNZW_8gQAU5teZacA5PGYUt85YiYjuwWQuzoCO6xpay10_CU97c2dAJQNlY4503SZS4vIwZ9RFzYgJFjRZotMk34y0sy3msnQ4KYwwffRJeTbKdDk7Fdx3sYrM4xrIVrSSgqBwTIv4p2qbB7JdM9tQDBUa0ga5PDssxBpn8JZYsdA_IZMgn4x1bja8ZF-Psbs8lgYfUpK1EbQ-YwGP8stHpZ_qv6rPXNNlsd5sDmWuWes5K0gCIhvrqRKLHca1hzTWEWmKXjGq9-aLuh356lLBilzu9Gh470zct1Wl8_3v5XWOWoFpGm_MBc3wLVEcAQXDrIPayZGkOSO8gcqQDH0E2FdN9rv_ClzEwuSffMPp62QJHRCgbSPZWONnnxuK6TZQK42wHwu5-aCw8bvkZt5LuA"
+)
+puts "Restaurants created"
+
+puts "Creating 5 Restaurants for Future deck..."
+item6 = Item.create!(
+  name: "Future Sürpriz - Berliner Kebab",
+  item_url: "https://www.surpriz.paris/",
+  address: "110 Rue Oberkampf, 75011 Paris",
+  rating: 4.7,
+  price_range: 1,
+  item_type: "Restaurant",
+  photo_url: "https://storage.googleapis.com/mon-resto-halal/restaurants/ce93030e-dbe8-4357-9cce-c630fc628c75/thumb@1024_e1df9f14-b6ba-453c-85bc-ac6dab538cf8.jpg"
+)
+item7 = Item.create!(
+  name: "Future Sukhumvit Thaï Street Food Paris 11",
+  item_url: "https://www.instagram.com/sukhumvit.paris11/",
+  address: "88 Rue Oberkampf, 75011 Paris",
+  rating: 4.7,
+  price_range: 0,
+  item_type: "Restaurant",
+  photo_url: "https://lh3.googleusercontent.com/p/AF1QipPX6bNfUxmIoN4atu0Y8HavtfYQJIDX-T_h3wLh=w1080-h608-p-no-v0"
+)
+item8 = Item.create!(
+  name: "Future Boulangerie Chambelland",
+  item_url: "https://chambelland.com/",
+  address: "14 Rue Ternaux, 75011 Paris",
+  rating: 4.4,
+  price_range: 2,
+  item_type: "Restaurant",
+  photo_url: "https://www.ixelles.city/_custom_storage/collections/137/chambelland_20190517_73670.jpg"
+)
+item9 = Item.create!(
+  name: "Future Açaï & You - St Ambroise (Brunch & Bowls Take away)",
+  item_url: "http://www.acaiandyou.com/",
+  address: "28 Rue Saint-Ambroise, 75011 Paris",
+  rating: 4.8,
+  price_range: 0,
+  item_type: "Restaurant",
+  photo_url: "https://meilleur-brunch.com/wp-content/uploads/2021/11/acaiandyou2_5_1125.jpeg"
+)
+item10 = Item.create!(
+  name: "Future Scaria",
+  item_url: "http://scaria.fr/",
+  address: "88 Ave Parmentier, 75011 Paris",
+  rating: 4.6,
+  price_range: 2,
+  item_type: "Restaurant",
+  photo_url: "https://v2cdn1.centralappstatic.com/cache?url=gwBZASxXb5aRoDFLzKC_tPBNZW_8gQAU5teZacA5PGYUt85YiYjuwWQuzoCO6xpay10_CU97c2dAJQNlY4503SZS4vIwZ9RFzYgJFjRZotMk34y0sy3msnQ4KYwwffRJeTbKdDk7Fdx3sYrM4xrIVrSSgqBwTIv4p2qbB7JdM9tQDBUa0ga5PDssxBpn8JZYsdA_IZMgn4x1bja8ZF-Psbs8lgYfUpK1EbQ-YwGP8stHpZ_qv6rPXNNlsd5sDmWuWes5K0gCIhvrqRKLHca1hzTWEWmKXjGq9-aLuh356lLBilzu9Gh470zct1Wl8_3v5XWOWoFpGm_MBc3wLVEcAQXDrIPayZGkOSO8gcqQDH0E2FdN9rv_ClzEwuSffMPp62QJHRCgbSPZWONnnxuK6TZQK42wHwu5-aCw8bvkZt5LuA"
+)
+puts "Restaurants created"
+
+puts "Creation de Deck_Items"
+deck_item1 = DeckItem.create!(item: item1, deck: restaurantdeck1)
+deck_item1 = DeckItem.create!(item: item2, deck: restaurantdeck1)
+deck_item1 = DeckItem.create!(item: item3, deck: restaurantdeck1)
+deck_item1 = DeckItem.create!(item: item4, deck: restaurantdeck1)
+deck_item1 = DeckItem.create!(item: item5, deck: restaurantdeck1)
+puts "finished"


### PR DESCRIPTION
J'ai ajouté :
- des dependent: :destroy dans la majorité des models car ils étaient nécessaires
- une column à la table des decks, afin qu'on ait un deck_type
- 5 items à la seed
- 1 deck_items à la seed (dans un deck Pending assigné à Hugo en plus des 2 decks Closed qui lui sont déjà assignés)

J'ai modifié le champ "type" de la table item pour mettre "item_type" à la place